### PR TITLE
Revert "Commit for release 1.16.2"

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -34,7 +34,7 @@ pygmentsUseClasses = true
   # we change the version for the complete docs when forking of a release branch
   # etc.
   # The full version string as referenced in Maven (e.g. 1.2.1)
-  Version = "1.16.2"
+  Version = "1.16.0"
 
   # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
   # release this should be the same as the regular version

--- a/flink-annotations/pom.xml
+++ b/flink-annotations/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-annotations</artifactId>

--- a/flink-architecture-tests/flink-architecture-tests-base/pom.xml
+++ b/flink-architecture-tests/flink-architecture-tests-base/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-architecture-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-architecture-tests-base</artifactId>

--- a/flink-architecture-tests/flink-architecture-tests-production/pom.xml
+++ b/flink-architecture-tests/flink-architecture-tests-production/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-architecture-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-architecture-tests-production</artifactId>

--- a/flink-architecture-tests/flink-architecture-tests-test/pom.xml
+++ b/flink-architecture-tests/flink-architecture-tests-test/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-architecture-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-architecture-tests-test</artifactId>

--- a/flink-architecture-tests/pom.xml
+++ b/flink-architecture-tests/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-architecture-tests</artifactId>

--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-clients</artifactId>

--- a/flink-connectors/flink-connector-aws-base/pom.xml
+++ b/flink-connectors/flink-connector-aws-base/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-aws-base</artifactId>

--- a/flink-connectors/flink-connector-aws-kinesis-firehose/pom.xml
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-aws-kinesis-firehose</artifactId>

--- a/flink-connectors/flink-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connectors/flink-connector-aws-kinesis-streams/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-aws-kinesis-streams</artifactId>

--- a/flink-connectors/flink-connector-base/pom.xml
+++ b/flink-connectors/flink-connector-base/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-base</artifactId>

--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-cassandra_${scala.binary.version}</artifactId>

--- a/flink-connectors/flink-connector-elasticsearch-base/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch-base/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch-base</artifactId>

--- a/flink-connectors/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch6/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch6</artifactId>

--- a/flink-connectors/flink-connector-elasticsearch7/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch7/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-elasticsearch7</artifactId>

--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-files</artifactId>

--- a/flink-connectors/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connectors/flink-connector-gcp-pubsub/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-gcp-pubsub</artifactId>

--- a/flink-connectors/flink-connector-hbase-1.4/pom.xml
+++ b/flink-connectors/flink-connector-hbase-1.4/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-hbase-1.4</artifactId>

--- a/flink-connectors/flink-connector-hbase-2.2/pom.xml
+++ b/flink-connectors/flink-connector-hbase-2.2/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-hbase-2.2</artifactId>

--- a/flink-connectors/flink-connector-hbase-base/pom.xml
+++ b/flink-connectors/flink-connector-hbase-base/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-hbase-base</artifactId>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-hive_${scala.binary.version}</artifactId>

--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-jdbc</artifactId>

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-kafka</artifactId>

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-kinesis</artifactId>

--- a/flink-connectors/flink-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-connector-pulsar/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-pulsar</artifactId>

--- a/flink-connectors/flink-connector-rabbitmq/pom.xml
+++ b/flink-connectors/flink-connector-rabbitmq/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-rabbitmq</artifactId>

--- a/flink-connectors/flink-file-sink-common/pom.xml
+++ b/flink-connectors/flink-file-sink-common/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-file-sink-common</artifactId>

--- a/flink-connectors/flink-hadoop-compatibility/pom.xml
+++ b/flink-connectors/flink-hadoop-compatibility/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-hadoop-compatibility_${scala.binary.version}</artifactId>

--- a/flink-connectors/flink-hcatalog/pom.xml
+++ b/flink-connectors/flink-hcatalog/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-hcatalog_${scala.binary.version}</artifactId>

--- a/flink-connectors/flink-sql-connector-aws-kinesis-firehose/pom.xml
+++ b/flink-connectors/flink-sql-connector-aws-kinesis-firehose/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-connectors/flink-sql-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connectors/flink-sql-connector-aws-kinesis-streams/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-connector-elasticsearch6</artifactId>

--- a/flink-connectors/flink-sql-connector-elasticsearch7/pom.xml
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-connector-elasticsearch7</artifactId>

--- a/flink-connectors/flink-sql-connector-hbase-1.4/pom.xml
+++ b/flink-connectors/flink-sql-connector-hbase-1.4/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-connectors/flink-sql-connector-hbase-2.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hbase-2.2/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-connectors/flink-sql-connector-hive-2.3.9/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.3.9/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-connector-hive-2.3.9_${scala.binary.version}</artifactId>

--- a/flink-connectors/flink-sql-connector-hive-3.1.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-3.1.2/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-connector-hive-3.1.2_${scala.binary.version}</artifactId>

--- a/flink-connectors/flink-sql-connector-kafka/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-connector-kafka</artifactId>

--- a/flink-connectors/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-sql-connector-kinesis/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-connector-kinesis</artifactId>

--- a/flink-connectors/flink-sql-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-sql-connector-pulsar/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-connector-pulsar</artifactId>

--- a/flink-connectors/flink-sql-connector-rabbitmq/pom.xml
+++ b/flink-connectors/flink-sql-connector-rabbitmq/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-connector-rabbitmq</artifactId>

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 

--- a/flink-container/pom.xml
+++ b/flink-container/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-container</artifactId>

--- a/flink-contrib/flink-connector-wikiedits/pom.xml
+++ b/flink-contrib/flink-connector-wikiedits/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-contrib</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-wikiedits</artifactId>

--- a/flink-contrib/pom.xml
+++ b/flink-contrib/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-contrib</artifactId>

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-core</artifactId>

--- a/flink-dist-scala/pom.xml
+++ b/flink-dist-scala/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-dist-scala_${scala.binary.version}</artifactId>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-dist_${scala.binary.version}</artifactId>

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-docs</artifactId>

--- a/flink-dstl/flink-dstl-dfs/pom.xml
+++ b/flink-dstl/flink-dstl-dfs/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-dstl</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-dstl-dfs</artifactId>

--- a/flink-dstl/pom.xml
+++ b/flink-dstl/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-dstl</artifactId>

--- a/flink-end-to-end-tests/flink-batch-sql-test/pom.xml
+++ b/flink-end-to-end-tests/flink-batch-sql-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-cli-test/pom.xml
+++ b/flink-end-to-end-tests/flink-cli-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
+++ b/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-connector-gcp-pubsub-emulator-tests</artifactId>

--- a/flink-end-to-end-tests/flink-dataset-allround-test/pom.xml
+++ b/flink-end-to-end-tests/flink-dataset-allround-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-dataset-allround-test</artifactId>

--- a/flink-end-to-end-tests/flink-dataset-fine-grained-recovery-test/pom.xml
+++ b/flink-end-to-end-tests/flink-dataset-fine-grained-recovery-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-dataset-fine-grained-recovery-test</artifactId>

--- a/flink-end-to-end-tests/flink-datastream-allround-test/pom.xml
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-datastream-allround-test</artifactId>

--- a/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/pom.xml
+++ b/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-firehose/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-firehose/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-streams/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-streams/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-elasticsearch/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-elasticsearch/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch6/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch6/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch7/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch7/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-hbase/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hbase/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-scala/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-scala/pom.xml
@@ -21,7 +21,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>flink-end-to-end-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>1.16.2</version>
+        <version>1.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-file-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-file-sink-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-glue-schema-registry-json-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-json-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-heavy-deployment-stress-test/pom.xml
+++ b/flink-end-to-end-tests/flink-heavy-deployment-stress-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-heavy-deployment-stress-test</artifactId>

--- a/flink-end-to-end-tests/flink-high-parallelism-iterations-test/pom.xml
+++ b/flink-end-to-end-tests/flink-high-parallelism-iterations-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-high-parallelism-iterations-test</artifactId>

--- a/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/pom.xml
+++ b/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-metrics-availability-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-availability-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-netty-shuffle-memory-control-test/pom.xml
+++ b/flink-end-to-end-tests/flink-netty-shuffle-memory-control-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-netty-shuffle-memory-control-test</artifactId>

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/pom.xml
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-program/pom.xml
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-program/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-plugins-test/another-dummy-fs/pom.xml
+++ b/flink-end-to-end-tests/flink-plugins-test/another-dummy-fs/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-plugins-test</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-plugins-test/dummy-fs/pom.xml
+++ b/flink-end-to-end-tests/flink-plugins-test/dummy-fs/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-plugins-test</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-plugins-test/pom.xml
+++ b/flink-end-to-end-tests/flink-plugins-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <artifactId>flink-end-to-end-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>1.16.2</version>
+        <version>1.16-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/flink-end-to-end-tests/flink-python-test/pom.xml
+++ b/flink-end-to-end-tests/flink-python-test/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
+++ b/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-quickstart-test/pom.xml
+++ b/flink-end-to-end-tests/flink-quickstart-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-rocksdb-state-memory-control-test/pom.xml
+++ b/flink-end-to-end-tests/flink-rocksdb-state-memory-control-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-sql-gateway-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-gateway-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <artifactId>flink-end-to-end-tests</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>1.16.2</version>
+        <version>1.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-state-evolution-test/pom.xml
+++ b/flink-end-to-end-tests/flink-state-evolution-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-stream-sql-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-sql-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-stream-state-ttl-test</artifactId>

--- a/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-streaming-kafka-test-base/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kafka-test-base/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-streaming-kafka-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kafka-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-tpcds-test/pom.xml
+++ b/flink-end-to-end-tests/flink-tpcds-test/pom.xml
@@ -21,7 +21,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-tpch-test/pom.xml
+++ b/flink-end-to-end-tests/flink-tpch-test/pom.xml
@@ -21,7 +21,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<packaging>pom</packaging>

--- a/flink-examples/flink-examples-batch/pom.xml
+++ b/flink-examples/flink-examples-batch/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-examples</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-examples-batch_${scala.binary.version}</artifactId>

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-examples-build-helper</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-examples-streaming-gcp-pubsub_${scala.binary.version}</artifactId>

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-examples-build-helper</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-examples-streaming-state-machine_${scala.binary.version}</artifactId>

--- a/flink-examples/flink-examples-build-helper/pom.xml
+++ b/flink-examples/flink-examples-build-helper/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-examples</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-examples-build-helper</artifactId>

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-examples</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-examples-streaming_${scala.binary.version}</artifactId>

--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-examples</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<name>Flink : Examples : Table</name>

--- a/flink-examples/pom.xml
+++ b/flink-examples/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-examples</artifactId>

--- a/flink-external-resources/flink-external-resource-gpu/pom.xml
+++ b/flink-external-resources/flink-external-resource-gpu/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<artifactId>flink-external-resources</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-external-resource-gpu</artifactId>

--- a/flink-external-resources/pom.xml
+++ b/flink-external-resources/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-external-resources</artifactId>

--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-azure-fs-hadoop</artifactId>

--- a/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-fs-hadoop-shaded</artifactId>

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-gs-fs-hadoop</artifactId>

--- a/flink-filesystems/flink-hadoop-fs/pom.xml
+++ b/flink-filesystems/flink-hadoop-fs/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-hadoop-fs</artifactId>

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -21,7 +21,7 @@ under the License.
 	<parent>
 		<artifactId>flink-filesystems</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-s3-fs-base</artifactId>

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-s3-fs-hadoop</artifactId>

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-s3-fs-presto</artifactId>

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-filesystems</artifactId>

--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-formats</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-formats/flink-avro-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-avro-glue-schema-registry/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-formats</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-avro</artifactId>

--- a/flink-formats/flink-compress/pom.xml
+++ b/flink-formats/flink-compress/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-compress</artifactId>

--- a/flink-formats/flink-csv/pom.xml
+++ b/flink-formats/flink-csv/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-csv</artifactId>

--- a/flink-formats/flink-format-common/pom.xml
+++ b/flink-formats/flink-format-common/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <artifactId>flink-formats</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>1.16.2</version>
+        <version>1.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-formats/flink-hadoop-bulk/pom.xml
+++ b/flink-formats/flink-hadoop-bulk/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-hadoop-bulk</artifactId>

--- a/flink-formats/flink-json-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-json-glue-schema-registry/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-formats</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-formats/flink-json/pom.xml
+++ b/flink-formats/flink-json/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-json</artifactId>

--- a/flink-formats/flink-orc-nohive/pom.xml
+++ b/flink-formats/flink-orc-nohive/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-orc-nohive</artifactId>

--- a/flink-formats/flink-orc/pom.xml
+++ b/flink-formats/flink-orc/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-orc</artifactId>

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-parquet</artifactId>

--- a/flink-formats/flink-protobuf/pom.xml
+++ b/flink-formats/flink-protobuf/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-protobuf</artifactId>

--- a/flink-formats/flink-sequence-file/pom.xml
+++ b/flink-formats/flink-sequence-file/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sequence-file</artifactId>

--- a/flink-formats/flink-sql-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-sql-avro-confluent-registry/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-avro-confluent-registry</artifactId>

--- a/flink-formats/flink-sql-avro/pom.xml
+++ b/flink-formats/flink-sql-avro/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-avro</artifactId>

--- a/flink-formats/flink-sql-csv/pom.xml
+++ b/flink-formats/flink-sql-csv/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-csv</artifactId>

--- a/flink-formats/flink-sql-json/pom.xml
+++ b/flink-formats/flink-sql-json/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-json</artifactId>

--- a/flink-formats/flink-sql-orc/pom.xml
+++ b/flink-formats/flink-sql-orc/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-orc</artifactId>

--- a/flink-formats/flink-sql-parquet/pom.xml
+++ b/flink-formats/flink-sql-parquet/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-parquet</artifactId>

--- a/flink-formats/flink-sql-protobuf/pom.xml
+++ b/flink-formats/flink-sql-protobuf/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-protobuf</artifactId>

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/flink-fs-tests/pom.xml
+++ b/flink-fs-tests/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-fs-tests</artifactId>

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-java</artifactId>

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-kubernetes</artifactId>

--- a/flink-libraries/flink-cep-scala/pom.xml
+++ b/flink-libraries/flink-cep-scala/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-libraries</artifactId>
-        <version>1.16.2</version>
+        <version>1.16-SNAPSHOT</version>
     </parent>
     
     <artifactId>flink-cep-scala_${scala.binary.version}</artifactId>

--- a/flink-libraries/flink-cep/pom.xml
+++ b/flink-libraries/flink-cep/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-libraries</artifactId>
-        <version>1.16.2</version>
+        <version>1.16-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-cep</artifactId>

--- a/flink-libraries/flink-gelly-examples/pom.xml
+++ b/flink-libraries/flink-gelly-examples/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-libraries</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-gelly-examples_${scala.binary.version}</artifactId>

--- a/flink-libraries/flink-gelly-scala/pom.xml
+++ b/flink-libraries/flink-gelly-scala/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-libraries</artifactId>
-        <version>1.16.2</version>
+        <version>1.16-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flink-libraries/flink-gelly/pom.xml
+++ b/flink-libraries/flink-gelly/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-libraries</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-gelly</artifactId>

--- a/flink-libraries/flink-state-processing-api/pom.xml
+++ b/flink-libraries/flink-state-processing-api/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-libraries</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-state-processor-api</artifactId>

--- a/flink-libraries/pom.xml
+++ b/flink-libraries/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-libraries</artifactId>

--- a/flink-metrics/flink-metrics-core/pom.xml
+++ b/flink-metrics/flink-metrics-core/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-metrics-core</artifactId>

--- a/flink-metrics/flink-metrics-datadog/pom.xml
+++ b/flink-metrics/flink-metrics-datadog/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-metrics-datadog</artifactId>

--- a/flink-metrics/flink-metrics-dropwizard/pom.xml
+++ b/flink-metrics/flink-metrics-dropwizard/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-metrics-dropwizard</artifactId>

--- a/flink-metrics/flink-metrics-graphite/pom.xml
+++ b/flink-metrics/flink-metrics-graphite/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-metrics-graphite</artifactId>

--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-metrics-influxdb</artifactId>

--- a/flink-metrics/flink-metrics-jmx/pom.xml
+++ b/flink-metrics/flink-metrics-jmx/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-metrics-jmx</artifactId>

--- a/flink-metrics/flink-metrics-prometheus/pom.xml
+++ b/flink-metrics/flink-metrics-prometheus/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-metrics-prometheus</artifactId>

--- a/flink-metrics/flink-metrics-slf4j/pom.xml
+++ b/flink-metrics/flink-metrics-slf4j/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-metrics-slf4j</artifactId>

--- a/flink-metrics/flink-metrics-statsd/pom.xml
+++ b/flink-metrics/flink-metrics-statsd/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-metrics-statsd</artifactId>

--- a/flink-metrics/pom.xml
+++ b/flink-metrics/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-metrics</artifactId>

--- a/flink-optimizer/pom.xml
+++ b/flink-optimizer/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-optimizer</artifactId>

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-python</artifactId>

--- a/flink-python/pyflink/version.py
+++ b/flink-python/pyflink/version.py
@@ -20,4 +20,4 @@
 The pyflink version will be consistent with the flink version and follow the PEP440.
 .. seealso:: https://www.python.org/dev/peps/pep-0440
 """
-__version__ = "1.16.2"
+__version__ = "1.16.dev0"

--- a/flink-queryable-state/flink-queryable-state-client-java/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-client-java/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-queryable-state</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-queryable-state-client-java</artifactId>

--- a/flink-queryable-state/flink-queryable-state-runtime/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-runtime/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-queryable-state</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-queryable-state-runtime</artifactId>

--- a/flink-queryable-state/pom.xml
+++ b/flink-queryable-state/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-queryable-state</artifactId>

--- a/flink-quickstart/flink-quickstart-java/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-quickstart</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-quickstart-java</artifactId>

--- a/flink-quickstart/flink-quickstart-scala/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-quickstart</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-quickstart-scala</artifactId>

--- a/flink-quickstart/pom.xml
+++ b/flink-quickstart/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-quickstart</artifactId>

--- a/flink-rpc/flink-rpc-akka-loader/pom.xml
+++ b/flink-rpc/flink-rpc-akka-loader/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-rpc</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-rpc-akka-loader</artifactId>

--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-rpc</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-rpc-akka</artifactId>

--- a/flink-rpc/flink-rpc-core/pom.xml
+++ b/flink-rpc/flink-rpc-core/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-rpc</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-rpc-core</artifactId>

--- a/flink-rpc/pom.xml
+++ b/flink-rpc/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-rpc</artifactId>

--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-runtime-web</artifactId>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-runtime</artifactId>

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-scala_${scala.binary.version}</artifactId>

--- a/flink-state-backends/flink-statebackend-changelog/pom.xml
+++ b/flink-state-backends/flink-statebackend-changelog/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-state-backends</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-statebackend-changelog</artifactId>

--- a/flink-state-backends/flink-statebackend-common/pom.xml
+++ b/flink-state-backends/flink-statebackend-common/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-state-backends</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-state-backends/flink-statebackend-heap-spillable/pom.xml
+++ b/flink-state-backends/flink-statebackend-heap-spillable/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-state-backends</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-statebackend-heap-spillable</artifactId>

--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-state-backends</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-statebackend-rocksdb</artifactId>

--- a/flink-state-backends/pom.xml
+++ b/flink-state-backends/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-state-backends</artifactId>

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-streaming-java</artifactId>

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-client</artifactId>

--- a/flink-table/flink-sql-gateway-api/pom.xml
+++ b/flink-table/flink-sql-gateway-api/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-table</artifactId>
-        <version>1.16.2</version>
+        <version>1.16-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-sql-gateway-api</artifactId>

--- a/flink-table/flink-sql-gateway/pom.xml
+++ b/flink-table/flink-sql-gateway/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>flink-table</artifactId>
         <groupId>org.apache.flink</groupId>
-        <version>1.16.2</version>
+        <version>1.16-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-sql-gateway</artifactId>

--- a/flink-table/flink-sql-parser-hive/pom.xml
+++ b/flink-table/flink-sql-parser-hive/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-table</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-parser-hive</artifactId>

--- a/flink-table/flink-sql-parser/pom.xml
+++ b/flink-table/flink-sql-parser/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-table</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-sql-parser</artifactId>

--- a/flink-table/flink-table-api-bridge-base/pom.xml
+++ b/flink-table/flink-table-api-bridge-base/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-api-bridge-base</artifactId>

--- a/flink-table/flink-table-api-java-bridge/pom.xml
+++ b/flink-table/flink-table-api-java-bridge/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-api-java-bridge</artifactId>

--- a/flink-table/flink-table-api-java-uber/pom.xml
+++ b/flink-table/flink-table-api-java-uber/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-api-java-uber</artifactId>

--- a/flink-table/flink-table-api-java/pom.xml
+++ b/flink-table/flink-table-api-java/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-api-java</artifactId>

--- a/flink-table/flink-table-api-scala-bridge/pom.xml
+++ b/flink-table/flink-table-api-scala-bridge/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-api-scala-bridge_${scala.binary.version}</artifactId>

--- a/flink-table/flink-table-api-scala/pom.xml
+++ b/flink-table/flink-table-api-scala/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-api-scala_${scala.binary.version}</artifactId>

--- a/flink-table/flink-table-code-splitter/pom.xml
+++ b/flink-table/flink-table-code-splitter/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-table</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-code-splitter</artifactId>

--- a/flink-table/flink-table-common/pom.xml
+++ b/flink-table/flink-table-common/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-common</artifactId>

--- a/flink-table/flink-table-planner-loader-bundle/pom.xml
+++ b/flink-table/flink-table-planner-loader-bundle/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-planner-loader-bundle</artifactId>

--- a/flink-table/flink-table-planner-loader/pom.xml
+++ b/flink-table/flink-table-planner-loader/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-planner-loader</artifactId>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-planner_${scala.binary.version}</artifactId>

--- a/flink-table/flink-table-runtime/pom.xml
+++ b/flink-table/flink-table-runtime/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-runtime</artifactId>

--- a/flink-table/flink-table-test-utils/pom.xml
+++ b/flink-table/flink-table-test-utils/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table-test-utils</artifactId>

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-table</artifactId>

--- a/flink-test-utils-parent/flink-connector-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-connector-test-utils/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-test-utils-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<!-- This module is the test module separated from flink-connector-base to avoid introducing

--- a/flink-test-utils-parent/flink-test-utils-junit/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils-junit/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-test-utils-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-test-utils-junit</artifactId>

--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-test-utils-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-test-utils</artifactId>

--- a/flink-test-utils-parent/pom.xml
+++ b/flink-test-utils-parent/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-test-utils-parent</artifactId>

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-tests</artifactId>

--- a/flink-walkthroughs/flink-walkthrough-common/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-common/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-walkthroughs</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-walkthrough-common</artifactId>

--- a/flink-walkthroughs/flink-walkthrough-datastream-java/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-datastream-java/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-walkthroughs</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-walkthrough-datastream-java</artifactId>

--- a/flink-walkthroughs/flink-walkthrough-datastream-scala/pom.xml
+++ b/flink-walkthroughs/flink-walkthrough-datastream-scala/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-walkthroughs</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-walkthrough-datastream-scala</artifactId>

--- a/flink-walkthroughs/pom.xml
+++ b/flink-walkthroughs/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-walkthroughs</artifactId>

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<!--

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>flink-yarn</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
 
 	<groupId>org.apache.flink</groupId>
 	<artifactId>flink-parent</artifactId>
-	<version>1.16.2</version>
+	<version>1.16-SNAPSHOT</version>
 
 	<name>Flink : </name>
 	<packaging>pom</packaging>
@@ -175,7 +175,7 @@ under the License.
 			For Hadoop 2.7, the minor Hadoop version supported for flink-shaded-hadoop-2-uber is 2.7.5
 		-->
 		<hivemetastore.hadoop.version>2.7.5</hivemetastore.hadoop.version>
-		<japicmp.referenceVersion>1.16.1</japicmp.referenceVersion>
+		<japicmp.referenceVersion>1.16.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
 		<spotless.version>2.13.0</spotless.version>
 		<spotless.scalafmt.version>3.4.3</spotless.scalafmt.version>

--- a/tools/ci/flink-ci-tools/pom.xml
+++ b/tools/ci/flink-ci-tools/pom.xml
@@ -25,12 +25,12 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.16.2</version>
+		<version>1.16-SNAPSHOT</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 
 	<artifactId>flink-ci-tools</artifactId>
-	<version>1.16.2</version>
+	<version>1.16-SNAPSHOT</version>
 	<name>Flink : Tools : CI : Java</name>
 
 	<properties>


### PR DESCRIPTION
Done so that https://github.com/aiven/flink/pull/51 can be merged without conflicts